### PR TITLE
Update footer copyright year

### DIFF
--- a/site/src/components/layout/footer.js
+++ b/site/src/components/layout/footer.js
@@ -1,31 +1,19 @@
-import {Link} from 'gatsby';
-import React from 'react';
-import { FooterStyle } from '../../styles/_layout/_footer.style';
+import { Link } from "gatsby";
+import React from "react";
+import { FooterStyle } from "../../styles/_layout/_footer.style";
 
 const Footer = () => {
-    return (
-        <div>
-            <FooterStyle
-                  className="dark-mode"
-            >
-                <div
-                    className="links"
-                >
-                    <Link
-                        to="https://www.linkedin.com/in/samhung/"
-                    >
-                        linkedin
-                    </Link>
-                    <Link
-                        to="https://github.com/shung93"
-                    >
-                        github
-                    </Link>
-                </div>
-                <p>© 2022</p>
-            </FooterStyle>
+  return (
+    <div>
+      <FooterStyle className="dark-mode">
+        <div className="links">
+          <Link to="https://www.linkedin.com/in/samhung/">linkedin</Link>
+          <Link to="https://github.com/shung93">github</Link>
         </div>
-    )
+        <p>© {new Date().getFullYear()}</p>
+      </FooterStyle>
+    </div>
+  );
 };
 
 export default Footer;


### PR DESCRIPTION
## Background
This PR is to update the hard-coded `2022` copyright year in the footer to use the current year

**Before**:
<img width="1801" alt="ShungPR1--before" src="https://github.com/shung93/portfolio/assets/20213406/e0a2789e-52a1-4d7a-b521-6c9acedd4f5a">

**After**:
<img width="1801" alt="ShungPR1--after" src="https://github.com/shung93/portfolio/assets/20213406/2a4dc6ce-8f1c-427c-94a2-6c58e7b32174">

## What's changed
- Updated `footer.js` to use a `Date` object instead of a hard-coded string for the year